### PR TITLE
UX: Add Readability settings menu

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,23 @@
+:root {
+  --reader-mode-font-family: inherit;
+  --reader-mode-text-color: var(--primary);
+  --reader-mode-bg-color: var(--secondary);
+  --reader-mode-font-size: inherit;
+  --reader-mode-h1-font-size: var(--font-up-3-rem);
+  --reader-mode-h2-font-size: var(--font-up-2-rem);
+  --reader-mode-h3-font-size: var(--font-up-1-rem);
+  --reader-mode-h4-font-size: var(--font-0-rem);
+  --reader-mode-h5-font-size: var(--font-down-1-rem);
+  --reader-mode-h6-font-size: var(--font-down-2-rem);
+  --reader-mode-small-font-size: 0.75rem;
+  --reader-mode-big-font-size: 1.5rem;
+  --reader-mode-offset: 0;
+  --topic-grid-width: auto auto;
+  --reader-mode-topic-body-width: calc(
+    var(--topic-body-width) + var(--topic-body-width-padding) * 2
+  );
+}
+
 .timeline-controls {
   display: flex;
   .reader-mode-toggle {
@@ -44,13 +64,16 @@
 }
 
 .reader-mode {
+  .container.posts {
+    grid-template-columns: var(--topic-grid-width);
+  }
   .topic-area#topic::before {
     content: "";
     display: block;
     width: 100vw;
     height: 100vh;
     position: fixed;
-    background: var(--secondary);
+    background: var(--reader-mode-bg-color);
     opacity: 0.95;
     left: 0;
     top: 0;
@@ -75,10 +98,17 @@
   #topic-title {
     position: relative;
     z-index: 102;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5 {
+      font-family: var(--reader-mode-font-family) !important;
+    }
+    font-family: var(--reader-mode-font-family) !important;
   }
 
   .posts-wrapper {
-    background-color: var(--secondary);
     z-index: 102;
   }
 
@@ -136,7 +166,99 @@
   .d-header-icons,
   .topic-admin-menu-button,
   .timeline-scrollarea-wrapper,
-  .timeline-footer-controls {
+  .timeline-footer-controls,
+  .topic-map {
     pointer-events: none;
+  }
+  .topic-admin-menu-button-container {
+    display: none;
+  }
+  .reader-mode-options-trigger {
+    opacity: 1 !important;
+    position: relative;
+  }
+
+  // Post Width Stuff
+  .container.posts {
+    position: relative;
+    left: var(--reader-mode-offset) !important;
+    .row {
+      width: 100%;
+      max-width: unset;
+    }
+  }
+
+  .topic-body {
+    width: var(--reader-mode-topic-body-width) !important;
+  }
+
+  // Font stuff
+  .cooked {
+    color: var(--reader-mode-text-color) !important;
+    font-family: var(--reader-mode-font-family) !important;
+    p,
+    span,
+    ul li,
+    ol li {
+      font-size: var(--reader-mode-font-size) !important;
+    }
+    h1 {
+      font-size: var(--reader-mode-h1-font-size) !important;
+    }
+    h2 {
+      font-size: var(--reader-mode-h2-font-size) !important;
+    }
+    h3 {
+      font-size: var(--reader-mode-h3-font-size) !important;
+    }
+    h4 {
+      font-size: var(--reader-mode-h4-font-size) !important;
+    }
+    h5 {
+      font-size: var(--reader-mode-h5-font-size) !important;
+    }
+    h6 {
+      font-size: var(--reader-mode-h6-font-size) !important;
+    }
+    small {
+      font-size: var(--reader-mode-small-font-size) !important;
+    }
+    big {
+      font-size: var(--reader-mode-big-font-size) !important;
+    }
+  }
+}
+
+.reader-mode-options-content .fk-d-menu__inner-content {
+  border-radius: 2px;
+}
+
+.reader-mode-options {
+  --base-font-size: var(--base-font-size) !important;
+  &__body {
+    padding: 1em;
+  }
+  &__section {
+    margin-bottom: 0.5em;
+    border-bottom: 1px solid var(--primary-low);
+  }
+  &__section:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+  &__section-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5em 0;
+    gap: 0.5em;
+  }
+  &__section-item label,
+  &__section-item select {
+    margin: 0;
+    font-weight: normal;
+  }
+  &__section-item select {
+    padding: 0.5em;
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -199,7 +199,8 @@
     p,
     span,
     ul li,
-    ol li {
+    ol li,
+    table {
       font-size: var(--reader-mode-font-size) !important;
     }
     h1 {

--- a/javascripts/discourse/components/reader-mode-options.gjs
+++ b/javascripts/discourse/components/reader-mode-options.gjs
@@ -26,72 +26,21 @@ export default class ReaderModeOptions extends Component {
 
   @action
   selectFontSize(e) {
-    let mainFontVariable =
-      e.target.value === 0 ? "1em" : `${1 + e.target.value * 0.1}em`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-font-size",
-      mainFontVariable
-    );
+    const setFontSize = (property, baseValue) => {
+      const value =
+        e.target.value === 0 ? baseValue : baseValue + e.target.value * 0.1;
+      document.documentElement.style.setProperty(property, `${value}rem`);
+    };
 
-    let h1FontVariable =
-      e.target.value === 0 ? "1.517em" : `${1.517 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h1-font-size",
-      h1FontVariable
-    );
-
-    let h2FontVariable =
-      e.target.value === 0 ? "1.3195em" : `${1.3195 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h2-font-size",
-      h2FontVariable
-    );
-
-    let h3FontVariable =
-      e.target.value === 0 ? "1.1487em" : `${1.1487 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h3-font-size",
-      h3FontVariable
-    );
-
-    let h4FontVariable =
-      e.target.value === 0 ? "1rem" : `${1 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h4-font-size",
-      h4FontVariable
-    );
-
-    let h5FontVariable =
-      e.target.value === 0
-        ? "0.8706rem"
-        : `${0.8706 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h5-font-size",
-      h5FontVariable
-    );
-
-    let h6FontVariable =
-      e.target.value === 0
-        ? "0.7579rem"
-        : `${0.7579 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-h6-font-size",
-      h6FontVariable
-    );
-
-    let smallFontVariable =
-      e.target.value === 0 ? "0.75rem" : `${0.75 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-small-font-size",
-      smallFontVariable
-    );
-
-    let bigFontVariable =
-      e.target.value === 0 ? "1.5rem" : `${1.5 + e.target.value * 0.1}rem`;
-    document.documentElement.style.setProperty(
-      "--reader-mode-big-font-size",
-      bigFontVariable
-    );
+    setFontSize("--reader-mode-font-size", 1);
+    setFontSize("--reader-mode-h1-font-size", 1.517);
+    setFontSize("--reader-mode-h2-font-size", 1.3195);
+    setFontSize("--reader-mode-h3-font-size", 1.1487);
+    setFontSize("--reader-mode-h4-font-size", 1);
+    setFontSize("--reader-mode-h5-font-size", 0.8706);
+    setFontSize("--reader-mode-h6-font-size", 0.7579);
+    setFontSize("--reader-mode-small-font-size", 0.75);
+    setFontSize("--reader-mode-big-font-size", 1.5);
   }
 
   @action

--- a/javascripts/discourse/components/reader-mode-options.gjs
+++ b/javascripts/discourse/components/reader-mode-options.gjs
@@ -1,0 +1,204 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { array } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import icon from "discourse-common/helpers/d-icon";
+import DMenu from "float-kit/components/d-menu";
+
+export default class ReaderModeOptions extends Component {
+  @tracked showOptions = false;
+  @tracked originalWidth = undefined;
+
+  @action
+  toggleOptions() {
+    this.showOptions = !this.showOptions;
+  }
+
+  @action
+  selectFont(e) {
+    document.documentElement.style.setProperty(
+      "--reader-mode-font-family",
+      e.target.value
+    );
+  }
+
+  @action
+  selectFontSize(e) {
+    let mainFontVariable =
+      e.target.value === 0 ? "1em" : `${1 + e.target.value * 0.1}em`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-font-size",
+      mainFontVariable
+    );
+
+    let h1FontVariable =
+      e.target.value === 0 ? "1.517em" : `${1.517 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h1-font-size",
+      h1FontVariable
+    );
+
+    let h2FontVariable =
+      e.target.value === 0 ? "1.3195em" : `${1.3195 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h2-font-size",
+      h2FontVariable
+    );
+
+    let h3FontVariable =
+      e.target.value === 0 ? "1.1487em" : `${1.1487 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h3-font-size",
+      h3FontVariable
+    );
+
+    let h4FontVariable =
+      e.target.value === 0 ? "1rem" : `${1 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h4-font-size",
+      h4FontVariable
+    );
+
+    let h5FontVariable =
+      e.target.value === 0
+        ? "0.8706rem"
+        : `${0.8706 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h5-font-size",
+      h5FontVariable
+    );
+
+    let h6FontVariable =
+      e.target.value === 0
+        ? "0.7579rem"
+        : `${0.7579 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-h6-font-size",
+      h6FontVariable
+    );
+
+    let smallFontVariable =
+      e.target.value === 0 ? "0.75rem" : `${0.75 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-small-font-size",
+      smallFontVariable
+    );
+
+    let bigFontVariable =
+      e.target.value === 0 ? "1.5rem" : `${1.5 + e.target.value * 0.1}rem`;
+    document.documentElement.style.setProperty(
+      "--reader-mode-big-font-size",
+      bigFontVariable
+    );
+  }
+
+  @action
+  selectOffset(e) {
+    let contentWidthVariable = `-${e.target.value}px`;
+
+    let topicBodyWidth = parseInt(
+      window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue("--topic-body-width"),
+      10
+    );
+    let topicbodyWidthPadding = parseInt(
+      window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue("--topic-body-width-padding"),
+      10
+    );
+    let additionalWidth = parseInt(e.target.value, 10);
+    let topicBodyWidthVariable = `${
+      topicBodyWidth + additionalWidth + topicbodyWidthPadding * 2
+    }px`;
+
+    // Move the content to the left when width increases
+    document.documentElement.style.setProperty(
+      "--reader-mode-offset",
+      contentWidthVariable
+    );
+    // increase with of topic body
+    document.documentElement.style.setProperty(
+      "--reader-mode-topic-body-width",
+      topicBodyWidthVariable
+    );
+    // increase defined grid width for topic content
+    document.documentElement.style.setProperty(
+      "--topic-grid-width",
+      `${this.originalWidth + parseInt(e.target.value, 10)}px auto`
+    );
+  }
+
+  @action
+  setTopicWidth() {
+    this.originalWidth = document.documentElement
+      .querySelector(".post-stream .topic-post")
+      .getBoundingClientRect().width;
+    document.documentElement.style.setProperty(
+      "--topic-grid-width",
+      `${this.originalWidth}px auto`
+    );
+  }
+
+  <template>
+    <DMenu
+      {{didInsert this.setTopicWidth}}
+      @identifier="reader-mode-options"
+      @triggers={{array "click"}}
+      @placementStrategy="fixed"
+      @class="reader-mode-options"
+    >
+      <:trigger>
+        {{icon "cog"}}
+      </:trigger>
+      <:content>
+        <div class="reader-mode-options__body">
+          <div class="reader-mode-options__section">
+            <h3 class="reader-mode-options__section-title">Readability</h3>
+            <div class="reader-mode-options__section-content">
+              <div class="reader-mode-options__section-item">
+                <label for="font-family">Font Style</label>
+                <select id="font-family" {{on "input" this.selectFont}}>
+                  <option value="Arial">Arial</option>
+                  <option value="Arial Black">Arial Black</option>
+                  <option value="Serif">Serif</option>
+                  <option value="sans-serif">Sans-serif</option>
+                  <option value="Times New Roman">Times New Roman</option>
+                  <option value="Courier New">Courier New</option>
+                  <option value="Courier">Courier</option>
+                </select>
+              </div>
+              <div class="reader-mode-options__section-item">
+                <label for="font-size">Font Size</label>
+                <input
+                  type="range"
+                  id="font-size"
+                  min="0"
+                  max="10"
+                  step="1"
+                  value="0"
+                  {{on "input" this.selectFontSize}}
+                />
+              </div>
+              <div class="reader-mode-options__section-item">
+                <label for="content-width">Content Width</label>
+                <input
+                  type="range"
+                  id="content-width"
+                  min="1"
+                  max="208"
+                  step="1"
+                  value="0"
+                  {{on "input" this.selectOffset}}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </:content>
+    </DMenu>
+  </template>
+}

--- a/javascripts/discourse/components/reader-mode-toggle.gjs
+++ b/javascripts/discourse/components/reader-mode-toggle.gjs
@@ -7,6 +7,7 @@ import DButton from "discourse/components/d-button";
 import bodyClass from "discourse/helpers/body-class";
 import concatClass from "discourse/helpers/concat-class";
 import discourseLater from "discourse-common/lib/later";
+import ReaderModeOptions from "./reader-mode-options";
 
 export default class ReaderModeToggle extends Component {
   @tracked readerModeActive = false;
@@ -61,5 +62,8 @@ export default class ReaderModeToggle extends Component {
         (if this.readerModeActive "active")
       }}
     />
+    {{#if this.readerModeActive}}
+      <ReaderModeOptions />
+    {{/if}}
   </template>
 }


### PR DESCRIPTION
This PR adds a readability settings menu next to the reader mode icon. You can now adjust:
- content width
- font size
- font family


https://github.com/discourse/reader-mode/assets/30537603/fd02d9dd-719d-4604-b11d-6f0d36c68704




