### PR TITLE
UX: Remove transitions

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -29,20 +29,20 @@
   }
 }
 
-#reply-control.open,
-.extra-info-wrapper,
-.video-placeholder-container {
-  transition: filter 0.3s;
-}
+// #reply-control.open,
+// .extra-info-wrapper,
+// .video-placeholder-container {
+//   transition: filter 0.3s;
+// }
 
-.post-notice,
-.time-gap.small-action {
-  transition: height 0.3s, opacity 0.3s;
-}
+// .post-notice,
+// .time-gap.small-action {
+//   transition: height 0.3s, opacity 0.3s;
+// }
 
-.topic-map {
-  transition: height 0.3s, opacity 0.5s;
-}
+// .topic-map {
+//   transition: height 0.3s, opacity 0.5s;
+// }
 
 #post_1 .topic-body,
 #post_1 .topic-avatar {
@@ -54,14 +54,14 @@
   border-top: 1px solid transparent;
 }
 
-.header-sidebar-toggle,
-.home-logo-wrapper-outlet,
-.d-header-icons,
-.timeline-controls .btn:not(.reader-mode-toggle),
-.timeline-scrollarea-wrapper,
-.timeline-footer-controls {
-  transition: opacity 0.3s;
-}
+// .header-sidebar-toggle,
+// .home-logo-wrapper-outlet,
+// .d-header-icons,
+// .timeline-controls .btn:not(.reader-mode-toggle),
+// .timeline-scrollarea-wrapper,
+// .timeline-footer-controls {
+//   transition: opacity 0.3s;
+// }
 
 .reader-mode {
   .d-header {
@@ -94,7 +94,7 @@
 
   .discourse-reactions-counter {
     opacity: 0;
-    transition: opacity 0.3s;
+    // transition: opacity 0.3s;
   }
 
   .extra-info-wrapper,
@@ -159,7 +159,7 @@
   .topic-avatar img,
   .topic-avatar .avatar-flair {
     opacity: 0.125;
-    transition: opacity 0.3s;
+    // transition: opacity 0.3s;
     filter: grayscale(1);
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -29,21 +29,6 @@
   }
 }
 
-// #reply-control.open,
-// .extra-info-wrapper,
-// .video-placeholder-container {
-//   transition: filter 0.3s;
-// }
-
-// .post-notice,
-// .time-gap.small-action {
-//   transition: height 0.3s, opacity 0.3s;
-// }
-
-// .topic-map {
-//   transition: height 0.3s, opacity 0.5s;
-// }
-
 #post_1 .topic-body,
 #post_1 .topic-avatar {
   border-top: 1px solid transparent;
@@ -53,15 +38,6 @@
 .time-gap + .topic-post .topic-avatar {
   border-top: 1px solid transparent;
 }
-
-// .header-sidebar-toggle,
-// .home-logo-wrapper-outlet,
-// .d-header-icons,
-// .timeline-controls .btn:not(.reader-mode-toggle),
-// .timeline-scrollarea-wrapper,
-// .timeline-footer-controls {
-//   transition: opacity 0.3s;
-// }
 
 .reader-mode {
   .d-header {
@@ -94,7 +70,6 @@
 
   .discourse-reactions-counter {
     opacity: 0;
-    // transition: opacity 0.3s;
   }
 
   .extra-info-wrapper,
@@ -159,7 +134,6 @@
   .topic-avatar img,
   .topic-avatar .avatar-flair {
     opacity: 0.125;
-    // transition: opacity 0.3s;
     filter: grayscale(1);
   }
 


### PR DESCRIPTION
This PR removes most of the transitions from the css. They were overriding core transitions, affecting the use of the forum.