### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/javascripts/discourse/components/reader-mode-options.gjs
+++ b/javascripts/discourse/components/reader-mode-options.gjs
@@ -104,14 +104,14 @@ export default class ReaderModeOptions extends Component {
                 <DButton
                   @action={{this.readerMode.decrementOffset}}
                   @preventFocus={{true}}
-                  @icon="compress-alt"
+                  @icon="down-left-and-up-right-to-center"
                   class="btn-flat reader-mode-options__item-button decrease-width text-changes"
                   @disabled={{if (eq this.readerMode.offsetIncrement 0) "true"}}
                 />
                 <DButton
                   @action={{this.readerMode.incrementOffset}}
                   @preventFocus={{true}}
-                  @icon="arrows-alt-h"
+                  @icon="left-right"
                   class="btn-flat reader-mode-options__item-button increase-width text-changes"
                   @disabled={{if
                     (eq

--- a/javascripts/discourse/components/reader-mode-toggle.gjs
+++ b/javascripts/discourse/components/reader-mode-toggle.gjs
@@ -44,7 +44,7 @@ export default class ReaderModeToggle extends Component {
       {{didInsert this.readerMode.setupWidth}}
       {{willDestroy this.cleanUpEventListener}}
       @action={{this.readerMode.toggleReaderMode}}
-      @icon="book-reader"
+      @icon="book-open-reader"
       @preventFocus={{true}}
       title="Toggle Reader Mode (ctrl + alt + r)"
       class={{concatClass

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,4 @@
 svg_icons:
-  default: "font|arrows-alt-h|compress-alt"
+  default: "font|left-right|down-left-and-up-right-to-center"
   type: "list"
   list_type: "compact"


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.