### PR TITLE
DEV: Fix compatibility with the Glimmer Post Stream

### DIFF
--- a/javascripts/services/reader-mode.js
+++ b/javascripts/services/reader-mode.js
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import { next } from "@ember/runloop";
+import { schedule } from "@ember/runloop";
 import Service from "@ember/service";
 import discourseLater from "discourse/lib/later";
 
@@ -146,8 +146,9 @@ export default class ReaderMode extends Service {
 
   @action
   setupWidth() {
-    // TODO (glimmer-post-stream): remove the call to next once the PostStream widget is modernized
-    next(() => {
+    // TODO (glimmer-post-stream): deferring to schedule("afterRender") won't be needed once the PostStream widget is
+    //  modernized
+    schedule("afterRender", () => {
       if (
         document.documentElement.style.getPropertyValue(
           "--reader-mode-topic-grid"

--- a/javascripts/services/reader-mode.js
+++ b/javascripts/services/reader-mode.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { next } from "@ember/runloop";
 import Service from "@ember/service";
 import discourseLater from "discourse/lib/later";
 
@@ -145,45 +146,51 @@ export default class ReaderMode extends Service {
 
   @action
   setupWidth() {
-    if (
-      document.documentElement.style.getPropertyValue(
-        "--reader-mode-topic-grid"
-      )
-    ) {
-      return;
-    }
+    // TODO (glimmer-post-stream): remove the call to next once the PostStream widget is modernized
+    next(() => {
+      if (
+        document.documentElement.style.getPropertyValue(
+          "--reader-mode-topic-grid"
+        )
+      ) {
+        return;
+      }
 
-    this.topicGridWidth =
-      Math.round(
-        10 *
-          document.documentElement
-            .querySelector(".post-stream .topic-post")
-            .getBoundingClientRect().width
-      ) / 10;
+      this.topicGridWidth =
+        Math.round(
+          10 *
+            document.documentElement
+              .querySelector(".post-stream .topic-post")
+              .getBoundingClientRect().width
+        ) / 10;
 
-    localStorage.setItem("readerModeTopicGridWidth", this.topicGridWidth);
+      localStorage.setItem("readerModeTopicGridWidth", this.topicGridWidth);
 
-    this.timelineGridWidth =
-      Math.round(
-        10 *
-          document.documentElement
-            .querySelector(".topic-navigation")
-            .getBoundingClientRect().width
-      ) / 10;
+      this.timelineGridWidth =
+        Math.round(
+          10 *
+            document.documentElement
+              .querySelector(".topic-navigation")
+              .getBoundingClientRect().width
+        ) / 10;
 
-    localStorage.setItem("readerModeTimelineGridWidth", this.timelineGridWidth);
-
-    let hasDiscoToc =
-      document.documentElement.querySelector(".d-toc-installed");
-
-    if (hasDiscoToc) {
-      this.setProperty("--reader-mode-topic-grid", "75% 25%");
-    } else {
-      this.setProperty(
-        "--reader-mode-topic-grid",
-        `${this.topicGridWidth}px ${this.timelineGridWidth}px`
+      localStorage.setItem(
+        "readerModeTimelineGridWidth",
+        this.timelineGridWidth
       );
-    }
+
+      let hasDiscoToc =
+        document.documentElement.querySelector(".d-toc-installed");
+
+      if (hasDiscoToc) {
+        this.setProperty("--reader-mode-topic-grid", "75% 25%");
+      } else {
+        this.setProperty(
+          "--reader-mode-topic-grid",
+          `${this.topicGridWidth}px ${this.timelineGridWidth}px`
+        );
+      }
+    });
   }
 
   setProperty(property, value) {


### PR DESCRIPTION
This change is needed because the TC handles the DOM elements once the component is inserted and while the `PostStream` widget isn't modernized the PostStream components are also performing the same task to include classes in some components.

Unfortunately, this was causing the TC to try to get properties from a selector that wasn't ready yet in the DOM.

Once the we have a Glimmer component version of the `PostStream` widget we will be able to revert the change.